### PR TITLE
Change profile and resulting jar names to match HV ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It is licensed under the Apache 2 license.
 |---------------------|------------------|-------------------|
 | Apache BVal         | `1.1.2`          | `bval`            |
 | Hibernate Validator | `5.4.2.Final`    | `hv-5.4`          |
-| Hibernate Validator | `6.0.7.Final`    | `hv-6.0-stable`   |
-| Hibernate Validator | `6.0.8-SNAPSHOT` | `hv-6.0-snapshot` |
+| Hibernate Validator | `6.0.7.Final`    | `hv-6.0`          |
+| Hibernate Validator | `6.0.8-SNAPSHOT` | `hv-current`      |
 
 ## Generating the beans
 
@@ -59,15 +59,15 @@ Assuming root is the current location:
 
 ```bash
 pushd jmh-benchmarks
-mvn clean package -Phv-6.0-snapshot
-mvn package -Phv-6.0-stable
+mvn clean package -Phv-current
+mvn package -Phv-6.0
 ```
 
 Finally, you can run the benchmarks as follows:
 
 ```bash
-java -jar target/bv-benchmarks-hv-${snapshot-version}.jar
-java -jar target/bv-benchmarks-hv-${stable-version}.jar
+java -jar target/bv-benchmarks-hv-current.jar
+java -jar target/bv-benchmarks-hv-6.0.jar
 popd
 ```
 

--- a/jmh-benchmarks/pom.xml
+++ b/jmh-benchmarks/pom.xml
@@ -91,7 +91,7 @@
 			<id>bval-1.1</id>
 			<properties>
 				<beanvalidation-impl.name>Apache BVal</beanvalidation-impl.name>
-				<beanvalidation-impl.short-name>bval</beanvalidation-impl.short-name>
+				<beanvalidation-impl.short-name>bval-1.1</beanvalidation-impl.short-name>
 				<beanvalidation-impl.version>${apache-bval.version}</beanvalidation-impl.version>
 			</properties>
 			<dependencies>
@@ -111,7 +111,7 @@
 			<id>hv-5.4</id>
 			<properties>
 				<beanvalidation-impl.name>Hibernate Validator</beanvalidation-impl.name>
-				<beanvalidation-impl.short-name>hv</beanvalidation-impl.short-name>
+				<beanvalidation-impl.short-name>hv-5.4</beanvalidation-impl.short-name>
 				<beanvalidation-impl.version>${hibernate-validator-5.4.version}</beanvalidation-impl.version>
 			</properties>
 			<dependencies>
@@ -128,10 +128,10 @@
 			</dependencies>
 		</profile>
 		<profile>
-			<id>hv-6.0-stable</id>
+			<id>hv-6.0</id>
 			<properties>
 				<beanvalidation-impl.name>Hibernate Validator</beanvalidation-impl.name>
-				<beanvalidation-impl.short-name>hv</beanvalidation-impl.short-name>
+				<beanvalidation-impl.short-name>hv-6.0</beanvalidation-impl.short-name>
 				<beanvalidation-impl.version>${hibernate-validator-6.0-stable.version}</beanvalidation-impl.version>
 			</properties>
 			<dependencies>
@@ -148,13 +148,13 @@
 			</dependencies>
 		</profile>
 		<profile>
-			<id>hv-6.0-snapshot</id>
+			<id>hv-current</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
 				<beanvalidation-impl.name>Hibernate Validator</beanvalidation-impl.name>
-				<beanvalidation-impl.short-name>hv</beanvalidation-impl.short-name>
+				<beanvalidation-impl.short-name>hv-current</beanvalidation-impl.short-name>
 				<beanvalidation-impl.version>${hibernate-validator-6.0-snapshot.version}</beanvalidation-impl.version>
 			</properties>
 			<dependencies>
@@ -194,7 +194,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>bv-benchmarks-${beanvalidation-impl.short-name}-${beanvalidation-impl.version}</finalName>
+							<finalName>bv-benchmarks-${beanvalidation-impl.short-name}</finalName>
 							<transformers>
 								<!-- Add a transformer to exclude any other manifest files (possibly from dependencies). -->
 								<transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">


### PR DESCRIPTION
@gsmet as we've talked in the previous PR - I've made some small changes so that these 
benchmarks would match more to the ones that we have in HV. I've changed the values of short-name property as it was only used in jar names.

- changed profiles for HV snapshot and latest stable versions to be the
same as the ones in HV - hv-current and hv-6.0
- changed names of resulting jar files to match the naming style of the
ones created in HV performance module
- updated README to reflect the name changes.